### PR TITLE
Added a clear() method to reset the cache

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,14 @@ where
         }
     }
 
+    pub fn clear(&mut self) {
+        // go through and call clear on everything
+        self.recent_set.clear();
+        self.recent_evicted.clear();
+        self.frequent_set.clear();
+        self.frequent_evicted.clear();
+    }
+
     pub fn len(&self) -> usize {
         self.recent_set.len() + self.frequent_set.len()
     }


### PR DESCRIPTION
Currently there is no `clear()` method, and so resetting/clearing the cache basically requires building a new one. That isn't terrible, except you have to go through the error handling to ensure `capacity` is valid. Having a dedicated `clear()` method resolves this issue.