### PR TITLE
arc-cache: allow building with custom hasher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2018"
 [dependencies]
 xlru-cache = "0.1"
 
+[dev-dependencies]
+nohash-hasher = "0.2"
+
 [badges]
 travis-ci = { repository = "jedisct1/rust-arc-cache" }
 appveyor  = { repository = "jedisct1/rust-arc-cache" }


### PR DESCRIPTION
This reuses the same interface from LruCache, but requires Clone.
It is generally useful for key types that could benefit from an optimized hasher.